### PR TITLE
Support connections to ports other than 443

### DIFF
--- a/lib/river/client.ex
+++ b/lib/river/client.ex
@@ -40,7 +40,7 @@ defmodule River.Client do
   # private
 
   defp do_request(%URI{} = uri, opts) do
-    {:ok, conn} = River.Conn.create(uri.host)
+    {:ok, conn} = River.Conn.create(uri.host, uri.port)
     River.Conn.request!(conn, build_request(uri, opts), opts.timeout)
   end
 


### PR DESCRIPTION
Hi there, I was poking around in the River source and wanted to test some things against a local server. This adds support for connecting to ports that are not port 443 :D. Also, if you're looking for help I'm interested in working on whatever needs to be done to get to a place where we can start using this for diplomat 😄.

It looks like continuation frames aren't quite working yet. That's something I could take a look at if you're not already working on it. Or anything else really! Just let me know!