### PR TITLE
Implement request header continuations

### DIFF
--- a/lib/river/conn.ex
+++ b/lib/river/conn.ex
@@ -4,7 +4,7 @@ defmodule River.Conn do
   require River.FrameTypes
   use Bitwise
   alias River.{Conn, Frame, Frame.Settings, Frame.WindowUpdate, Encoder,
-               Request, Stream, StreamHandler, FrameTypes}
+               Request, StreamHandler, FrameTypes}
 
   @default_header_table_size 4096
   @initial_window_size 65_535
@@ -71,7 +71,7 @@ defmodule River.Conn do
   end
 
   def request!(pid, %Request{}=req, timeout) do
-    Connection.cast(pid, {req, self})
+    Connection.cast(pid, {req, self()})
     listen(timeout)
   end
 
@@ -134,7 +134,7 @@ defmodule River.Conn do
     {:noreply, conn}
   end
 
-  defp add_stream(%{stream_id: id, streams: count, host: host}=conn, parent) do
+  defp add_stream(%{stream_id: id, streams: count}=conn, parent) do
     id = id + 2
     {:ok, _} = StreamHandler.get_pid(conn, id, parent)
     %{conn | stream_id: id, streams: count + 1}
@@ -197,10 +197,10 @@ defmodule River.Conn do
   # defp send_data(%{send_window: 0}=conn, req) do
   #   # we need some internal buffer here - we should defer to the stream
   # end
-  defp send_data(%{stream_id: stream_id, socket: socket} = conn, %{data: data}=req) do
+  defp send_data(%{stream_id: stream_id} = conn, %{data: data}=req) do
     # AHHH! duplication!
     case data do
-      <<payload::binary-size(@max_frame_size) , rest::binary>> ->
+      <<_payload::binary-size(@max_frame_size) , rest::binary>> ->
         frame =
           %Frame{
             type: FrameTypes.data,

--- a/lib/river/conn.ex
+++ b/lib/river/conn.ex
@@ -10,7 +10,6 @@ defmodule River.Conn do
   @initial_window_size 65_535
   @flow_control_increment 2_147_483_647
   @max_frame_size 16_384
-  # @max_frame_size 1048576
 
   defstruct [
     host:      nil,
@@ -141,21 +140,55 @@ defmodule River.Conn do
     %{conn | stream_id: id, streams: count + 1}
   end
 
-  defp send_headers(%{send_ctx: ctx, socket: socket, stream_id: id} = conn, req) do
-    frame = %Frame{
-      type: FrameTypes.headers,
-      stream_id: id,
-      flags: header_flags(req),
-      payload: %Frame.Headers{headers: Request.header_list(req)}
-    } |> Encoder.encode(ctx)
+  defp send_headers(%{send_ctx: ctx, socket: socket, stream_id: id} = conn, %{method: method} = req) do
+    fragments =
+      conn
+      |> header_block(req)
+      |> header_block_fragments(max_send_frame_size(conn))
+    frame_count = length(fragments)
 
-    :ssl.send(socket, frame)
+    frame_data =
+      fragments
+      |> Enum.with_index()
+      |> Enum.map(fn {fragment, i} ->
+        %Frame{
+          type: (if i == 0, do: FrameTypes.headers, else: FrameTypes.continuation),
+          stream_id: id,
+          flags: %{
+            end_headers: i == frame_count - 1,
+            end_stream: method == :get,
+          },
+          payload: %River.Frame.Headers{
+            header_block_fragment: fragment,
+          },
+          length: byte_size(fragment)
+        }
+        |> Encoder.encode(ctx)
+      end)
+      |> Enum.reduce(<<>>, &(&2 <> &1))
+      :ssl.send(socket, frame_data)
     conn
   end
 
-  # this isn't exactly right, as it doesn't allow us to send mutiple header frames
-  defp header_flags(%{method: :get}), do: %{end_headers: true, end_stream: true}
-  defp header_flags(_), do: %{end_headers: true}
+  defp header_block_fragments(block, max_size) do
+    case block do
+      <<fragment::binary-size(max_size), rest::binary>> ->
+        [fragment | header_block_fragments(rest, max_size)]
+      <<>> ->
+        []
+      fragment ->
+        [fragment]
+    end
+  end
+
+  defp max_send_frame_size(%{send_settings: settings}),
+    do: Keyword.get(settings, :MAX_FRAME_SIZE, @max_frame_size)
+
+  defp header_block(%{send_ctx: ctx} = _conn, request) do
+    request
+    |> Request.header_list()
+    |> HPack.encode(ctx)
+  end
 
   defp send_data(conn, %{method: :get}), do: conn
 

--- a/lib/river/encoder.ex
+++ b/lib/river/encoder.ex
@@ -1,7 +1,7 @@
 defmodule River.Encoder do
   require River.FrameTypes
   alias River.{Frame, FrameTypes}
-  alias River.Frame.{Data, GoAway, Headers, Ping, Priority, PushPromise, RstStream, Settings, WindowUpdate}
+  alias River.Frame.Settings
 
   def encode(%Frame{} = frame, ctx \\ nil) do
     frame
@@ -14,7 +14,7 @@ defmodule River.Encoder do
     head <> body
   end
 
-  defp payload(%{type: FrameTypes.continuation, payload: %{header_block_fragment: fragment}} = frame, ctx) do
+  defp payload(%{type: FrameTypes.continuation, payload: %{header_block_fragment: fragment}} = frame, _ctx) do
     %{frame | __payload: fragment, length: byte_size(fragment)}
   end
 
@@ -33,14 +33,14 @@ defmodule River.Encoder do
     %{frame | __payload: body, length: byte_size(body)}
   end
 
-  defp payload(%{type: FrameTypes.headers, payload: %{header_block_fragment: fragment}} = frame, ctx) do
+  defp payload(%{type: FrameTypes.headers, payload: %{header_block_fragment: fragment}} = frame, _ctx) do
     %{frame | __payload: fragment}
     |> weighted_payload
     |> padded_payload
     |> put_length
   end
 
-  defp payload(%{type: FrameTypes.ping, flags: flags} = frame, _ctx) do
+  defp payload(%{type: FrameTypes.ping} = frame, _ctx) do
     %{frame | __payload: :binary.copy(<<0>>, 8), length: 8}
   end
 

--- a/lib/river/encoder.ex
+++ b/lib/river/encoder.ex
@@ -14,9 +14,8 @@ defmodule River.Encoder do
     head <> body
   end
 
-  defp payload(%{type: FrameTypes.continuation, payload: %{headers: headers}} = frame, ctx) do
-    encoded = HPack.encode(headers, ctx)
-    %{frame | __payload: encoded, length: byte_size(encoded)}
+  defp payload(%{type: FrameTypes.continuation, payload: %{header_block_fragment: fragment}} = frame, ctx) do
+    %{frame | __payload: fragment, length: byte_size(fragment)}
   end
 
   defp payload(%{type: FrameTypes.data, payload: %{data: data}} = frame, _ctx) do
@@ -34,8 +33,8 @@ defmodule River.Encoder do
     %{frame | __payload: body, length: byte_size(body)}
   end
 
-  defp payload(%{type: FrameTypes.headers, payload: %{headers: headers}} = frame, ctx) do
-    %{frame | __payload: HPack.encode(headers, ctx)}
+  defp payload(%{type: FrameTypes.headers, payload: %{header_block_fragment: fragment}} = frame, ctx) do
+    %{frame | __payload: fragment}
     |> weighted_payload
     |> padded_payload
     |> put_length

--- a/lib/river/flags.ex
+++ b/lib/river/flags.ex
@@ -5,7 +5,8 @@ defmodule River.Flags do
 
   def encode(%{} = flags) do
     flags
-    |> Enum.filter_map(fn({_k, v}) -> v end, fn({k, _v}) -> key_to_val(k) end)
+    |> Enum.filter(fn({_k, v}) -> v end)
+    |> Enum.map(fn({k, _v}) -> key_to_val(k) end)
     |> Enum.reduce(0, fn(el, acc) -> el ||| acc end)
   end
 

--- a/lib/river/frame.ex
+++ b/lib/river/frame.ex
@@ -14,7 +14,7 @@ defmodule River.Frame do
   ]
 
   defimpl Inspect, for: River.Frame do
-    def inspect(frame, opts) do
+    def inspect(frame, _opts) do
       Enum.join [
         "%River.Frame{",
         "stream_id: #{inspect frame.stream_id}",
@@ -110,11 +110,4 @@ defmodule River.Frame do
 
   defp parse_flags(FrameTypes.window_update, _flags),
     do: %{}
-
-  defp frame_type(FrameTypes.settings),     do: :SETTINGS
-  defp frame_type(FrameTypes.headers),      do: :HEADERS
-  defp frame_type(FrameTypes.data),         do: :DATA
-  defp frame_type(FrameTypes.rst_stream),   do: :RST_STREAM
-  defp frame_type(FrameTypes.push_promise), do: :PUSH_PROMISE
-  defp frame_type(FrameTypes.goaway),       do: :GOAWAY
 end

--- a/lib/river/frame/continuation.ex
+++ b/lib/river/frame/continuation.ex
@@ -1,8 +1,8 @@
 defmodule River.Frame.Continuation do
-  alias River.{Frame, Frame.Headers}
 
   defstruct [
     headers:   [],
+    header_block_fragment: <<>>,
   ]
 
   defmodule Flags do

--- a/lib/river/frame/headers.ex
+++ b/lib/river/frame/headers.ex
@@ -4,6 +4,7 @@ defmodule River.Frame.Headers do
   defstruct [
     padding:   0,
     headers:   [],
+    header_block_fragment: <<>>,
     exclusive: false,
     stream_dependency: nil,
     weight:    nil

--- a/lib/river/frame/push_promise.ex
+++ b/lib/river/frame/push_promise.ex
@@ -1,5 +1,5 @@
 defmodule River.Frame.PushPromise do
-  alias River.{Frame, Frame.Headers}
+  alias River.Frame
 
   defstruct [
     padding:   0,
@@ -52,7 +52,7 @@ defmodule River.Frame.PushPromise do
     end
   end
 
-  def decode(frame, payload, ctx) do
+  def decode(frame, payload, _ctx) do
     [frame, payload] |> IO.inspect
   end
 end

--- a/lib/river/request.ex
+++ b/lib/river/request.ex
@@ -35,7 +35,7 @@ defmodule River.Request do
   def add_headers(request, []),
     do: %{request | headers: Enum.reverse(request.headers)}
   # allow the user-agent to be overwritten
-  def add_headers(request, [{"user-agent", val}=ua | headers]) do
+  def add_headers(request, [{"user-agent", _val}=ua | headers]) do
     filtered = Enum.reject(request.headers, fn({key, _}) ->
       key == "user-agent"
     end)

--- a/lib/river/request.ex
+++ b/lib/river/request.ex
@@ -32,9 +32,8 @@ defmodule River.Request do
 
   def add_header(request, {_,_}=header),
     do: add_headers(request, [header])
-
-  def add_headers(request, []), do: %{request | headers: Enum.reverse(request.headers)}
-
+  def add_headers(request, []),
+    do: %{request | headers: Enum.reverse(request.headers)}
   # allow the user-agent to be overwritten
   def add_headers(request, [{"user-agent", val}=ua | headers]) do
     filtered = Enum.reject(request.headers, fn({key, _}) ->
@@ -43,13 +42,13 @@ defmodule River.Request do
 
     add_headers(%{request | headers: [ua | filtered]}, headers)
   end
-
   def add_headers(request, [{key, val} | headers])
       when key != ":method" and key != ":scheme" and key != ":path" and key != ":authority" do
     add_headers(%{request | headers: [{String.downcase(key), val} | request.headers]}, headers)
   end
-
-  def add_headers(request, [_ | headers]), do: add_headers(request, headers)
+  def add_headers(request, [_ | headers]) do
+    add_headers(request, headers)
+  end
 
   def header_list(%{uri: %{scheme: scheme, path: path, authority: auth},
                     method: method, headers: headers}) do

--- a/lib/river/response.ex
+++ b/lib/river/response.ex
@@ -1,6 +1,6 @@
 defmodule River.Response do
   require River.FrameTypes
-  alias River.{Response, Frame, Flags, FrameTypes}
+  alias River.{Frame, FrameTypes}
 
   defstruct [
     code:         nil,

--- a/lib/river/stream_handler.ex
+++ b/lib/river/stream_handler.ex
@@ -42,7 +42,7 @@ defmodule River.StreamHandler do
   end
 
   def send_frame(pid, %Frame{} = frame) do
-    Agent.cast(pid, fn({%{listener: cpid} = stream, response}) ->
+    Agent.cast(pid, fn({%{listener: _cpid} = stream, response}) ->
       # how should we handle this here...?
       # this is why we need to handle
       stream = Stream.send_frame(stream, frame)

--- a/test/river/frame/settings_test.exs
+++ b/test/river/frame/settings_test.exs
@@ -1,4 +1,3 @@
 defmodule River.Frame.SettingsTest do
   use ExUnit.Case, async: true
-  alias River.{Frame, Frame.Settings}
 end

--- a/test/river/frame_test.exs
+++ b/test/river/frame_test.exs
@@ -59,7 +59,7 @@ defmodule River.FrameTest do
 
     assert {:ok, %Frame{
                stream_id: 21,
-               length: length,
+               length: _length,
                flags: %{end_stream: true},
                payload: %Headers{
                  headers: ^headers

--- a/test/river/stream_handler_test.exs
+++ b/test/river/stream_handler_test.exs
@@ -31,20 +31,20 @@ defmodule River.StreamHandlerTest do
   end
 
   test "getting a frame with an :END_STREAM flag causes the handler to send a message" do
-    {:ok, pid} = StreamHandler.start_link([], %Stream{listener: self})
+    {:ok, pid} = StreamHandler.start_link([], %Stream{listener: self()})
     StreamHandler.recv_frame(pid, %Frame{type: FrameTypes.data, flags: %{end_stream: true}, payload: %Frame.Data{}})
     assert_receive {:ok, %Response{closed: true}}
   end
 
   test "getting a frame with an :END_STREAM flag causes the stream handler to stop itself" do
-    {:ok, pid} = StreamHandler.start_link([], %Stream{listener: self})
+    {:ok, pid} = StreamHandler.start_link([], %Stream{listener: self()})
     StreamHandler.recv_frame(pid, %Frame{type: FrameTypes.data, flags: %{end_stream: true}, payload: %Frame.Data{}})
     :timer.sleep(10)
     refute Process.alive?(pid)
   end
 
   test "getting a RST_STREAM frame causes the handler to send the error pack and stop itself" do
-    {:ok, pid} = StreamHandler.start_link([], %Stream{listener: self})
+    {:ok, pid} = StreamHandler.start_link([], %Stream{listener: self()})
     StreamHandler.recv_frame(pid, %Frame{type: FrameTypes.rst_stream, payload: %Frame.RstStream{error: 401}})
     assert_receive {:error, %Response{closed: true, code: 401}}
     :timer.sleep(10)

--- a/test/river_test.exs
+++ b/test/river_test.exs
@@ -58,7 +58,7 @@ defmodule RiverTest do
     @tag external: true
     test "a large PUT to the golang server" do
       body = (for n <- 1..100_000, do: Integer.to_charlist(n)) |> Enum.join
-      assert {:ok, %River.Response{code: 200}=resp} =
+      assert {:ok, %River.Response{code: 200}} =
         River.Client.put("https://http2.golang.org/crc32", body)
     end
   end
@@ -66,7 +66,7 @@ defmodule RiverTest do
   describe "nghttp2.org" do
     @tag external: true
     test "a simple get" do
-      assert {:ok, %River.Response{code: 200} = ng_resp} =
+      assert {:ok, %River.Response{code: 200}} =
         River.Client.get("https://nghttp2.org/")
     end
   end

--- a/test/river_test.exs
+++ b/test/river_test.exs
@@ -39,6 +39,15 @@ defmodule RiverTest do
     end
 
     @tag external: true
+    test "a GET with large headers" do
+      cookie = :crypto.strong_rand_bytes(30_000) |> Base.url_encode64()
+      headers = [{"cookie", cookie}]
+      assert {:ok, %River.Response{code: 200} = resp} =
+        River.Client.get("https://http2.golang.org/", headers: headers)
+      assert byte_size(resp.body) > 0
+    end
+
+    @tag external: true
     test "a PUT to the golang server" do
       body = "hello"
       assert {:ok, %River.Response{code: 200}=resp} =


### PR DESCRIPTION
This implements continuation frames for requests. Responses should follow here soon.

This also fixes all compiler warnings. It's been broken up into two commits to make reading the diff a bit easier.